### PR TITLE
Add setting hyperslab size to Block and Topography interfaces

### DIFF
--- a/libsrc/geomodelgrids/serial/Block.hh
+++ b/libsrc/geomodelgrids/serial/Block.hh
@@ -72,6 +72,14 @@ public:
      */
     size_t getNumValues(void) const;
 
+    /** Set hyperslab size.
+     *
+     * @param[in] dims Dimensions of hyperslab.
+     * @param[in] ndims Number of dimensions.
+     */
+    void setHyperslabDims(const size_t dims[],
+                          const size_t ndims);
+
     /** Prepare for querying.
      *
      * @param[in] h5 HDF5 with model.
@@ -113,6 +121,7 @@ private:
     double* _values;
     size_t _numValues; ///< Number of values stored at each grid point.
     size_t _dims[3]; ///< Number of points along grid in each coordinate dimension [x, y, z].
+    size_t _hyperslabDims[4]; ///< Dimensions of hyperslab.
 
 }; // Block
 

--- a/libsrc/geomodelgrids/serial/Topography.cc
+++ b/libsrc/geomodelgrids/serial/Topography.cc
@@ -17,6 +17,10 @@ geomodelgrids::serial::Topography::Topography(void) :
     _resolutionHoriz(0.0) {
     _dims[0] = 0;
     _dims[1] = 0;
+
+    _hyperslabDims[0] = 128;
+    _hyperslabDims[1] = 128;
+    _hyperslabDims[2] = 1;
 } // constructor
 
 
@@ -52,6 +56,26 @@ double
 geomodelgrids::serial::Topography::getResolutionHoriz(void) const {
     return _resolutionHoriz;
 } // getResolutionHoriz
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Set hyperslab size.
+void
+geomodelgrids::serial::Topography::setHyperslabDims(const size_t dims[],
+                                                    const size_t ndimsIn) {
+    const size_t ndims = 2; // 3rd dimension is 1.
+    if (2 != ndimsIn) {
+        std::ostringstream msg;
+        msg << "Expected array of length " << ndims << " for hyperslab dimension, got array of length "
+            << ndimsIn << ".";
+        throw std::length_error(msg.str().c_str());
+    } // if
+    assert(dims);
+
+    for (int i = 0; i < ndims; ++i) {
+        _hyperslabDims[i] = dims[i];
+    } // for
+} // setHyperslabDims
 
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/libsrc/geomodelgrids/serial/Topography.hh
+++ b/libsrc/geomodelgrids/serial/Topography.hh
@@ -32,6 +32,14 @@ public:
      */
     double getResolutionHoriz(void) const;
 
+    /** Set hyperslab size.
+     *
+     * @param[in] dims Dimensions of hyperslab.
+     * @param[in] ndims Number of dimensions.
+     */
+    void setHyperslabDims(const size_t dims[],
+                          const size_t ndims);
+
     /** Prepare for querying.
      *
      * @param[in] h5 HDF5 with model.
@@ -56,6 +64,7 @@ private:
     geomodelgrids::serial::Hyperslab* _hyperslab; ///< Hyperslab of data in model.
     double _resolutionHoriz; ///< Horizontal resolution (m).
     size_t _dims[2]; ///< Number of points along grid in each x and y dimension [x, y].
+    size_t _hyperslabDims[3]; ///< Dimensions of hyperslab.
 
 }; // Topography
 

--- a/tests/libtests/serial/TestBlock.cc
+++ b/tests/libtests/serial/TestBlock.cc
@@ -25,6 +25,7 @@ class geomodelgrids::serial::TestBlock : public CppUnit::TestFixture {
 
     CPPUNIT_TEST(testConstructor);
     CPPUNIT_TEST(testAccessors);
+    CPPUNIT_TEST(testSetHyperslabDims);
     CPPUNIT_TEST(testLoadMetadata);
     CPPUNIT_TEST(testQuery);
 
@@ -39,6 +40,9 @@ public:
     /// Test getters.
     void testAccessors(void);
 
+    /// Test setHyperslabDims.
+    void testSetHyperslabDims(void);
+
     /// Test loadMetadata().
     void testLoadMetadata(void);
 
@@ -48,7 +52,7 @@ public:
 }; // class TestBlock
 CPPUNIT_TEST_SUITE_REGISTRATION(geomodelgrids::serial::TestBlock);
 
-// ----------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
 // Test constructor.
 void
 geomodelgrids::serial::TestBlock::testConstructor(void) {
@@ -67,7 +71,7 @@ geomodelgrids::serial::TestBlock::testConstructor(void) {
 } // testConstructor
 
 
-// ----------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
 // Test getters.
 void
 geomodelgrids::serial::TestBlock::testAccessors(void) {
@@ -97,7 +101,34 @@ geomodelgrids::serial::TestBlock::testAccessors(void) {
 } // testAccessors
 
 
-// ----------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
+// Test setHyperslabDims.
+void
+geomodelgrids::serial::TestBlock::testSetHyperslabDims(void) {
+    const std::string blockName("myblock");
+    Block block(blockName.c_str());
+
+    const size_t ndims = 4;
+    const size_t dimsDefault[ndims] = { 64, 64, 0, 0 };
+    for (size_t i = 0; i < ndims; ++i) {
+        std::ostringstream msg;
+        msg << "Mismath in default hyperslab dim " << i << ".";
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str().c_str(), dimsDefault[i], block._hyperslabDims[i]);
+    } // for
+
+    const size_t dims[ndims] = { 12, 12, 4, 0 };
+    block.setHyperslabDims(dims, ndims-1);
+    for (size_t i = 0; i < ndims; ++i) {
+        std::ostringstream msg;
+        msg << "Mismath in user hyperslab dim " << i << ".";
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str().c_str(), dims[i], block._hyperslabDims[i]);
+    } // for
+
+    CPPUNIT_ASSERT_THROW(block.setHyperslabDims(dims, 5), std::length_error);
+} // testSetHyperslabDims
+
+
+// ---------------------------------------------------------------------------------------------------------------------
 // Test loadMetadata().
 void
 geomodelgrids::serial::TestBlock::testLoadMetadata(void) {
@@ -127,7 +158,7 @@ geomodelgrids::serial::TestBlock::testLoadMetadata(void) {
 } // testLoadMetadata
 
 
-// ----------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
 // Test query().
 void
 geomodelgrids::serial::TestBlock::testQuery(void) {

--- a/tests/libtests/serial/TestTopography.cc
+++ b/tests/libtests/serial/TestTopography.cc
@@ -25,6 +25,7 @@ class geomodelgrids::serial::TestTopography : public CppUnit::TestFixture {
 
     CPPUNIT_TEST(testConstructor);
     CPPUNIT_TEST(testAccessors);
+    CPPUNIT_TEST(testSetHyperslabDims);
     CPPUNIT_TEST(testLoadMetadata);
     CPPUNIT_TEST(testQuery);
 
@@ -39,6 +40,9 @@ public:
     /// Test getters.
     void testAccessors(void);
 
+    /// Test setHyperslabDims.
+    void testSetHyperslabDims(void);
+
     /// Test loadMetadata().
     void testLoadMetadata(void);
 
@@ -48,7 +52,7 @@ public:
 }; // class TestTopography
 CPPUNIT_TEST_SUITE_REGISTRATION(geomodelgrids::serial::TestTopography);
 
-// ----------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
 // Test constructor.
 void
 geomodelgrids::serial::TestTopography::testConstructor(void) {
@@ -60,7 +64,7 @@ geomodelgrids::serial::TestTopography::testConstructor(void) {
 } // testConstructor
 
 
-// ----------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
 // Test getters.
 void
 geomodelgrids::serial::TestTopography::testAccessors(void) {
@@ -75,7 +79,33 @@ geomodelgrids::serial::TestTopography::testAccessors(void) {
 } // testAccessors
 
 
-// ----------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
+// Test setHyperslabDims.
+void
+geomodelgrids::serial::TestTopography::testSetHyperslabDims(void) {
+    Topography topo;
+
+    const size_t ndims = 3;
+    const size_t dimsDefault[ndims] = { 128, 128, 1 };
+    for (size_t i = 0; i < ndims; ++i) {
+        std::ostringstream msg;
+        msg << "Mismath in default hyperslab dim " << i << ".";
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str().c_str(), dimsDefault[i], topo._hyperslabDims[i]);
+    } // for
+
+    const size_t dims[ndims] = { 12, 12, 1 };
+    topo.setHyperslabDims(dims, ndims-1);
+    for (size_t i = 0; i < ndims; ++i) {
+        std::ostringstream msg;
+        msg << "Mismath in user hyperslab dim " << i << ".";
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str().c_str(), dims[i], topo._hyperslabDims[i]);
+    } // for
+
+    CPPUNIT_ASSERT_THROW(topo.setHyperslabDims(dims, 5), std::length_error);
+} // testSetHyperslabDims
+
+
+// ---------------------------------------------------------------------------------------------------------------------
 // Test loadMetadata().
 void
 geomodelgrids::serial::TestTopography::testLoadMetadata(void) {
@@ -95,7 +125,7 @@ geomodelgrids::serial::TestTopography::testLoadMetadata(void) {
 } // testLoadMetadata
 
 
-// ----------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
 // Test query().
 void
 geomodelgrids::serial::TestTopography::testQuery(void) {


### PR DESCRIPTION
Replace hardwired hyperslab dimensions in Block and Topography to defaults and add method for user to set hyperslab dimensions.

Closes #23.