### PR TITLE
Fix h5py array of string attributes and chunking.

### DIFF
--- a/geomodelgrids/io/hdf5.py
+++ b/geomodelgrids/io/hdf5.py
@@ -2,6 +2,7 @@
 """
 
 import h5py
+import numpy
 
 
 class HDF5Storage():
@@ -58,7 +59,11 @@ class HDF5Storage():
         h5 = h5py.File(self.filename, "a")
         attrs = h5.attrs
         for attr in self.MODEL_ATTRS:
-            attrs[attr] = getattr(domain, attr)
+            value = getattr(domain, attr)
+            if isinstance(value, list) and isinstance(value[0], str):
+                attrs[attr] = [numpy.string_(v) for v in value]
+            else:
+                attrs[attr] = value
         h5.close()
 
     def save_topography(self, topography):

--- a/geomodelgrids/model.py
+++ b/geomodelgrids/model.py
@@ -29,7 +29,7 @@ class Block():
                     z_top: Elevation of top of block (m)
                     z_bot: Elevation of bottom of block (m)
                     z_top_offset: Vertical offset of top set of points below top of block (m)
-                    chunk_size: Size of dataset chunk (should be about 10Kb - 1Mb)
+                    chunk_size: Dimensions of dataset chunk (should be about 10Kb - 1Mb)
         """
         self.name = name
         self.resolution_horiz = float(config["resolution_horiz"])
@@ -37,7 +37,7 @@ class Block():
         self.z_top = float(config["z_top"])
         self.z_bot = float(config["z_bot"])
         self.z_top_offset = float(config["z_top_offset"])
-        self.chunk_size = map(int, config["chunk_size"])
+        self.chunk_size = tuple(map(int, string_to_list(config["chunk_size"])))
 
     def get_dims(self, domain):
         """Get number of points in block along each dimension.
@@ -128,12 +128,12 @@ class Topography():
              Keys:
                  use_topography: Model uses topography
                  resolution_horiz: Horizontal resolution in m
-                 chunk_size: Size of dataset chunk (should be about 10Kb - 1Mb)
+                 chunk_size: Dimensions of dataset chunk (should be about 10Kb - 1Mb)
         """
         self.elevation = None
         self.enabled = bool(config["use_topography"])
         self.resolution_horiz = float(config["resolution_horiz"]) if self.enabled else None
-        self.chunk_size = map(int, config["chunk_size"]) if self.enabled else None
+        self.chunk_size = tuple(map(int, string_to_list(config["chunk_size"]))) if self.enabled else None
 
     def set_elevation(self, elev):
         """Set topography values.


### PR DESCRIPTION
Use numpy.string_ (fixed length ASCII text) for array of strings attributes. This works for h5py at least 2.8.0 and 2.10.0.