### PR TITLE
Add header with command line arguments to query and elevation query output files

### DIFF
--- a/libsrc/geomodelgrids/apps/Borehole.cc
+++ b/libsrc/geomodelgrids/apps/Borehole.cc
@@ -223,7 +223,7 @@ geomodelgrids::apps::Borehole::_createOutputHeader(int argc,
     std::ostringstream header;
     header << "#";
     for (int i = 0; i < argc; ++i) {
-        header << " " << argv;
+        header << " " << argv[i];
     } // for
     header << "\n";
     return header.str();

--- a/libsrc/geomodelgrids/apps/Query.cc
+++ b/libsrc/geomodelgrids/apps/Query.cc
@@ -54,16 +54,17 @@ geomodelgrids::apps::Query::run(int argc,
 
     std::ifstream sin(_pointsFilename);
     std::ofstream sout(_outputFilename);
+    sout << _createOutputHeader(argc, argv);
     const size_t numQueryValues = _valueNames.size();
     std::vector<double> values(numQueryValues);
     sout << std::scientific << std::setprecision(6);
     while (true) {
         double srcX, srcY, srcZ;
         sin >> srcX >> srcY >> srcZ;
-	if (sin.eof() || !sin.good()) {
-	  break;
-	} // if
-	
+        if (sin.eof() || !sin.good()) {
+            break;
+        } // if
+
         query.query(&values[0], srcX, srcY, srcZ);
 
         sout << std::setw(14) << srcX
@@ -117,7 +118,7 @@ geomodelgrids::apps::Query::_parseArgs(int argc,
         } // 'v'
         case 's': {
             _squash = true;
-            _squashMinElev = atof(optarg);
+            _squashMinElev = std::stod(optarg);
             break;
         } // 's'
         case 'p': {
@@ -147,7 +148,7 @@ geomodelgrids::apps::Query::_parseArgs(int argc,
         } // 'm'
         case '?': {
             std::ostringstream msg;
-            msg << "Error passing command line arguments:\n";
+            msg << "Error parsing command line arguments:\n";
             for (int i = 0; i < argc; ++i) {
                 msg << argv[i] << " ";
             } // for
@@ -193,10 +194,25 @@ geomodelgrids::apps::Query::_printHelp(void) {
               << "    --models=FILE_0,...,FILE_M       Models to query (in order).\n"
               << "    --points=FILE_POINTS             Read input points from FILE_POINTS.\n"
               << "    --points-coordsys=PROJ|EPSG|WKT  Coordinate system of input points (default=EPSG:4326).\n"
-              << "    --log=FILE_LOG                   Write logging information to FILE_LOG."
+              << "    --log=FILE_LOG                   Write logging information to FILE_LOG.\n"
               << "    --output=FILE_OUTPUT             Write values to FILE_OUTPUT."
               << std::endl;
 } // _printHelp
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Create header for output.
+std::string
+geomodelgrids::apps::Query::_createOutputHeader(int argc,
+                                                char* argv[]) {
+    std::ostringstream header;
+    header << "#";
+    for (int i = 0; i < argc; ++i) {
+        header << " " << argv[i];
+    } // for
+    header << "\n";
+    return header.str();
+} // _createOutputHeader
 
 
 // End of file

--- a/libsrc/geomodelgrids/apps/Query.hh
+++ b/libsrc/geomodelgrids/apps/Query.hh
@@ -54,6 +54,14 @@ private:
     /// Print help information.
     void _printHelp(void);
 
+    /** Create header for output file.
+     *
+     * @param argc[in] Number of arguments passed.
+     * @param argv[in] Array of input arguments.
+     */
+    std::string _createOutputHeader(int argc,
+                                    char* argv[]);
+
     // PRIVATE MEMBERS /////////////////////////////////////////////////////////////////////////////////////////////////
 private:
 

--- a/libsrc/geomodelgrids/apps/QueryElev.cc
+++ b/libsrc/geomodelgrids/apps/QueryElev.cc
@@ -50,6 +50,7 @@ geomodelgrids::apps::QueryElev::run(int argc,
 
     std::ifstream sin(_pointsFilename);
     std::ofstream sout(_outputFilename);
+    sout << _createOutputHeader(argc, argv);
     sout << std::scientific << std::setprecision(6);
     while (true) {
         double srcX, srcY;
@@ -122,7 +123,7 @@ geomodelgrids::apps::QueryElev::_parseArgs(int argc,
         } // 'm'
         case '?': {
             std::ostringstream msg;
-            msg << "Error passing command line arguments:\n";
+            msg << "Error parsing command line arguments:\n";
             for (int i = 0; i < argc; ++i) {
                 msg << argv[i] << " ";
             } // for
@@ -165,10 +166,25 @@ geomodelgrids::apps::QueryElev::_printHelp(void) {
               << "    --models=FILE_0,...,FILE_M       Models to query (in order).\n"
               << "    --points=FILE_POINTS             Read input points from FILE_POINTS.\n"
               << "    --points-coordsys=PROJ|EPSG|WKT  Coordinate system of input points (default=EPSG:4326).\n"
-              << "    --log=FILE_LOG                   Write logging information to FILE_LOG."
+              << "    --log=FILE_LOG                   Write logging information to FILE_LOG.\n"
               << "    --output=FILE_OUTPUT             Write values to FILE_OUTPUT."
               << std::endl;
 } // _printHelp
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Create header for output.
+std::string
+geomodelgrids::apps::QueryElev::_createOutputHeader(int argc,
+                                                    char* argv[]) {
+    std::ostringstream header;
+    header << "#";
+    for (int i = 0; i < argc; ++i) {
+        header << " " << argv[i];
+    } // for
+    header << "\n";
+    return header.str();
+} // _createOutputHeader
 
 
 // End of file

--- a/libsrc/geomodelgrids/apps/QueryElev.hh
+++ b/libsrc/geomodelgrids/apps/QueryElev.hh
@@ -52,6 +52,14 @@ private:
     /// Print help information.
     void _printHelp(void);
 
+    /** Create header for output file.
+     *
+     * @param argc[in] Number of arguments passed.
+     * @param argv[in] Array of input arguments.
+     */
+    std::string _createOutputHeader(int argc,
+                                    char* argv[]);
+
     // PRIVATE MEMBERS /////////////////////////////////////////////////////////////////////////////////////////////////
 private:
 

--- a/tests/libtests/apps/TestBorehole.cc
+++ b/tests/libtests/apps/TestBorehole.cc
@@ -352,13 +352,11 @@ geomodelgrids::apps::_TestBorehole::checkBorehole(std::istream& sin,
         std::getline(sin, comment);
 
         double zBH;
-        sin >> zBH;
-        if (!sin.good()) { throw std::runtime_error("Could not read elevation in borehole."); }
+        sin >> zBH;CPPUNIT_ASSERT_MESSAGE("Could not read elevation in borehole.", sin.good());
 
         { // Value 'two'
             double value = NODATA_VALUE;
-            sin >> value;
-            if (!sin.good()) { throw std::runtime_error("Could not read value 'two' in borehole."); }
+            sin >> value;CPPUNIT_ASSERT_MESSAGE("Could not read value 'two' in output.", sin.good());
 
             const double valueE = points.computeValueTwo(x, y, z);
 
@@ -372,8 +370,7 @@ geomodelgrids::apps::_TestBorehole::checkBorehole(std::istream& sin,
 
         { // Value 'one'
             double value = NODATA_VALUE;
-            sin >> value;
-            if (!sin.good()) { throw std::runtime_error("Could not read value 'two' in borehole."); }
+            sin >> value;CPPUNIT_ASSERT_MESSAGE("Could not read value 'one' in output.", sin.good());
 
             const double valueE = points.computeValueOne(x, y, z);
 

--- a/tests/libtests/apps/TestQuery.cc
+++ b/tests/libtests/apps/TestQuery.cc
@@ -263,7 +263,7 @@ geomodelgrids::apps::TestQuery::testPrintHelp(void) {
     Query query;
     query._printHelp();
     std::cout.rdbuf(coutOrig);
-    CPPUNIT_ASSERT_EQUAL(size_t(864), coutHelp.str().length());
+    CPPUNIT_ASSERT_EQUAL(size_t(865), coutHelp.str().length());
 } // testPrintHelp
 
 
@@ -284,7 +284,7 @@ geomodelgrids::apps::TestQuery::testRunHelp(void) {
     query.run(nargs, const_cast<char**>(args));
 
     std::cout.rdbuf(coutOrig);
-    CPPUNIT_ASSERT_EQUAL(size_t(864), coutHelp.str().length());
+    CPPUNIT_ASSERT_EQUAL(size_t(865), coutHelp.str().length());
 } // testRunHelp
 
 

--- a/tests/libtests/apps/TestQuery.cc
+++ b/tests/libtests/apps/TestQuery.cc
@@ -311,6 +311,8 @@ geomodelgrids::apps::TestQuery::testRunOneBlockFlat(void) {
     query.run(nargs, const_cast<char**>(args));
 
     std::ifstream sin("one-block-flat.out");CPPUNIT_ASSERT(sin.is_open() && sin.good());
+    std::string comment;
+    std::getline(sin, comment);
     _TestQuery::checkQuery(sin, pointsOne);
     sin.close();
 
@@ -340,6 +342,8 @@ geomodelgrids::apps::TestQuery::testRunThreeBlocksTopo(void) {
     query.run(nargs, const_cast<char**>(args));
 
     std::ifstream sin("three-blocks-topo.out");CPPUNIT_ASSERT(sin.is_open() && sin.good());
+    std::string comment;
+    std::getline(sin, comment);
     _TestQuery::checkQuery(sin, pointsThree);
     sin.close();
 } // testRunThreeBlocksTopo
@@ -368,6 +372,8 @@ geomodelgrids::apps::TestQuery::testRunThreeBlocksSquash(void) {
     query.run(nargs, const_cast<char**>(args));
 
     std::ifstream sin("three-blocks-topo.out");CPPUNIT_ASSERT(sin.is_open() && sin.good());
+    std::string comment;
+    std::getline(sin, comment);
     _TestQuery::checkQuery(sin, pointsThree);
     sin.close();
 } // testRunThreeBlocksSquash
@@ -397,6 +403,9 @@ geomodelgrids::apps::TestQuery::testRunTwoModels(void) {
     query.run(nargs, const_cast<char**>(args));
 
     std::ifstream sin("two-models.out");CPPUNIT_ASSERT(sin.is_open() && sin.good());
+    std::string comment;
+    std::getline(sin, comment);
+
     _TestQuery::checkQuery(sin, pointsOne);
     _TestQuery::checkQuery(sin, pointsThree);
     sin.close();

--- a/tests/libtests/apps/TestQuery.cc
+++ b/tests/libtests/apps/TestQuery.cc
@@ -448,10 +448,11 @@ geomodelgrids::apps::_TestQuery::checkQuery(std::istream& sin,
         for (size_t iDim = 0; iDim < spaceDim; ++iDim) {
             sin >> xyz[iDim];
         } // for
+        CPPUNIT_ASSERT_MESSAGE("Could not read coordinates of point in output.", sin.good());
 
         { // Value 'two'
             double value = NODATA_VALUE;
-            sin >> value;
+            sin >> value;CPPUNIT_ASSERT_MESSAGE("Could not read value 'two' in output.", sin.good());
 
             const double valueE = points.computeValueTwo(x, y, z);
 
@@ -465,7 +466,7 @@ geomodelgrids::apps::_TestQuery::checkQuery(std::istream& sin,
 
         { // Value 'one'
             double value = NODATA_VALUE;
-            sin >> value;
+            sin >> value;CPPUNIT_ASSERT_MESSAGE("Could not read value 'one' in output.", sin.good());
 
             const double valueE = points.computeValueOne(x, y, z);
 

--- a/tests/libtests/apps/TestQueryElev.cc
+++ b/tests/libtests/apps/TestQueryElev.cc
@@ -404,9 +404,10 @@ geomodelgrids::apps::_TestQueryElev::checkQuery(std::istream& sin,
         for (size_t iDim = 0; iDim < 2; ++iDim) {
             sin >> xy[iDim];
         } // for
+        CPPUNIT_ASSERT_MESSAGE("Could not read coordinates of point in output.", sin.good());
 
         double value = NODATA_VALUE;
-        sin >> value;
+        sin >> value;CPPUNIT_ASSERT_MESSAGE("Could not read elevation in output.", sin.good());
 
         const double valueE = hasTopography ? points.computeElevation(x, y) : 0.0;
 

--- a/tests/libtests/apps/TestQueryElev.cc
+++ b/tests/libtests/apps/TestQueryElev.cc
@@ -296,6 +296,8 @@ geomodelgrids::apps::TestQueryElev::testRunOneBlockFlat(void) {
     query.run(nargs, const_cast<char**>(args));
 
     std::ifstream sin("one-block-flat.out");CPPUNIT_ASSERT(sin.is_open() && sin.good());
+    std::string comment;
+    std::getline(sin, comment);
     bool hasTopography = false;
     _TestQueryElev::checkQuery(sin, pointsOne, hasTopography);
     sin.close();
@@ -325,6 +327,8 @@ geomodelgrids::apps::TestQueryElev::testRunThreeBlocksTopo(void) {
     query.run(nargs, const_cast<char**>(args));
 
     std::ifstream sin("three-blocks-topo.out");CPPUNIT_ASSERT(sin.is_open() && sin.good());
+    std::string comment;
+    std::getline(sin, comment);
     bool hasTopography = true;
     _TestQueryElev::checkQuery(sin, pointsThree, hasTopography);
     sin.close();
@@ -354,6 +358,8 @@ geomodelgrids::apps::TestQueryElev::testRunTwoModels(void) {
     query.run(nargs, const_cast<char**>(args));
 
     std::ifstream sin("two-models.out");CPPUNIT_ASSERT(sin.is_open() && sin.good());
+    std::string comment;
+    std::getline(sin, comment);
     bool hasTopography = false;
     _TestQueryElev::checkQuery(sin, pointsOne, hasTopography);
     hasTopography = true;

--- a/tests/libtests/apps/TestQueryElev.cc
+++ b/tests/libtests/apps/TestQueryElev.cc
@@ -249,7 +249,7 @@ geomodelgrids::apps::TestQueryElev::testPrintHelp(void) {
     QueryElev query;
     query._printHelp();
     std::cout.rdbuf(coutOrig);
-    CPPUNIT_ASSERT_EQUAL(size_t(611), coutHelp.str().length());
+    CPPUNIT_ASSERT_EQUAL(size_t(612), coutHelp.str().length());
 } // testPrintHelp
 
 
@@ -270,7 +270,7 @@ geomodelgrids::apps::TestQueryElev::testRunHelp(void) {
     query.run(nargs, const_cast<char**>(args));
 
     std::cout.rdbuf(coutOrig);
-    CPPUNIT_ASSERT_EQUAL(size_t(611), coutHelp.str().length());
+    CPPUNIT_ASSERT_EQUAL(size_t(612), coutHelp.str().length());
 } // testRunHelp
 
 


### PR DESCRIPTION
Other small fixes:

* Add missing line feeds in `Query` and `QueryElev`.
* Check reading values in query tests.

Closes #65, #64 