### PR TITLE
Fix two query bugs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,11 +3,11 @@
     "telemetry.enableTelemetry": false,
     "telemetry.enableCrashReporter": false,
     "uncrustify.configPath.osx": "developer/uncrustify.cfg",
+    "uncrustify.configPath.linux": "developer/uncrustify.cfg",
     "files.associations": {
         "string": "cpp",
         "*.icc": "cpp"
     },
-    "python.pythonPath": "/Users/baagaard/tools/unix/python-3.8.3/clang-3.6.0/bin/python3",
     "python.formatting.autopep8Args": [
         "--max-line-length",
         "120",

--- a/docker/devenv-build.sh
+++ b/docker/devenv-build.sh
@@ -7,8 +7,8 @@ fi
 
 
 if [ $opttype == "debug" ]; then
-    CFLAGS="-g -Wterminate -Wall --coverage"
-    CXXFLAGS="-std=c++11 -g -Wall --coverage"
+    CFLAGS="-g -Wall --coverage"
+    CXXFLAGS="-std=c++11 -Wterminate -g -Wall --coverage"
 elif [ $opttype == "opt" ]; then
     CFLAGS="-O3 -march=native"
     CXXFLAGS="-std=c++11 -O3 -march=native -g"

--- a/libsrc/geomodelgrids/serial/Block.cc
+++ b/libsrc/geomodelgrids/serial/Block.cc
@@ -165,7 +165,7 @@ geomodelgrids::serial::Block::setHyperslabDims(const size_t dims[],
     } // if
     assert(dims);
 
-    for (int i = 0; i < ndims; ++i) {
+    for (size_t i = 0; i < ndims; ++i) {
         _hyperslabDims[i] = dims[i];
     } // for
 } // setHyperslabDims

--- a/libsrc/geomodelgrids/serial/Hyperslab.cc
+++ b/libsrc/geomodelgrids/serial/Hyperslab.cc
@@ -371,10 +371,11 @@ geomodelgrids::serial::_Hyperslab::_interpolate3D(double* const values,
         for (hsize_t iDim = 0; iDim < 2; ++iDim) {
             for (hsize_t jDim = 0; jDim < 2; ++jDim) {
                 for (hsize_t kDim = 0; kDim < 2; ++kDim) {
-                    if (_hyperslab._values[ii[iDim][jDim][kDim] + iValue] == geomodelgrids::NODATA_VALUE) {
+                    const double interpolateValue = _hyperslab._values[ii[iDim][jDim][kDim] + iValue];
+                    if (fabs(1.0 - interpolateValue/geomodelgrids::NODATA_VALUE) < 1.0e-3) {
                         hasNoDataValue = true;
                     } // if
-                    values[iValue] += wts[iDim][jDim][kDim] * _hyperslab._values[ii[iDim][jDim][kDim] + iValue];
+                    values[iValue] += wts[iDim][jDim][kDim] * interpolateValue;
                 } // for
             } // for
         } // for

--- a/libsrc/geomodelgrids/serial/Query.cc
+++ b/libsrc/geomodelgrids/serial/Query.cc
@@ -162,13 +162,15 @@ geomodelgrids::serial::Query::query(double* const values,
                 const double groundElev = _models[i]->queryElevation(x, y);
                 elevationSquash = z + groundElev;
             } // if
-            found = true;
 
             const double* modelValues = _models[i]->query(x, y, elevationSquash);
             values_map_type& modelMap = _valuesIndex[i];
             for (size_t iValue = 0; iValue < numQueryValues; ++iValue) {
                 values[iValue] = modelValues[modelMap[iValue]];
             } // for
+
+            found = true;
+	    break;
         } // if
     } // for
 

--- a/libsrc/geomodelgrids/serial/Topography.cc
+++ b/libsrc/geomodelgrids/serial/Topography.cc
@@ -92,7 +92,7 @@ geomodelgrids::serial::Topography::setHyperslabDims(const size_t dims[],
     } // if
     assert(dims);
 
-    for (int i = 0; i < ndims; ++i) {
+    for (size_t i = 0; i < ndims; ++i) {
         _hyperslabDims[i] = dims[i];
     } // for
 } // setHyperslabDims

--- a/tests/libtests/serial/TestHDF5.cc
+++ b/tests/libtests/serial/TestHDF5.cc
@@ -319,11 +319,11 @@ geomodelgrids::serial::TestHDF5::testReadDatasetHyperslab(void) {
     h5.readDatasetHyperslab((void*)values, dataset, origin, dims, ndims, H5T_NATIVE_DOUBLE);
 
     const double tolerance = 1.0e-6;
-    for (int ix = 0, i = 0; ix < dims[0]; ++ix) {
+    for (hsize_t ix = 0, i = 0; ix < dims[0]; ++ix) {
         const double x = res_horiz * (origin[0] + ix);
-        for (int iy = 0; iy < dims[1]; ++iy) {
+        for (hsize_t iy = 0; iy < dims[1]; ++iy) {
             const double y = res_horiz * (origin[1] + iy);
-            for (int iz = 0; iz < dims[2]; ++iz) {
+            for (hsize_t iz = 0; iz < dims[2]; ++iz) {
                 const double z = z_top - res_vert * (origin[2] + iz);
 
                 { // Value 0


### PR DESCRIPTION
Fix two C++ query bugs.

1. Fix multi-model query. Use values from first model found (not last).
2. Fix interpolation with NODATA_VALUE. Account for promotion from float to double.