### PR TITLE
FIX: Do not require vTop <= vBot for isosurface value of 0.0.

### DIFF
--- a/libsrc/geomodelgrids/apps/Isosurface.cc
+++ b/libsrc/geomodelgrids/apps/Isosurface.cc
@@ -541,7 +541,7 @@ geomodelgrids::apps::Isosurfacer::query(double* values,
             const double a = (vTop-vBot) / (zTop-zBot);
             const double b = vTop - a*zTop;
             values[iValue] = topElev - (vTarget - b) / a;
-        } else if ((vTarget <= vTop) && (vTop <= vBot)) {
+        } else if (vTarget < vTop) {
             values[iValue] = 0.0;
         } else {
             values[iValue] = geomodelgrids::NODATA_VALUE;


### PR DESCRIPTION
Change condition for isosurface value of 0.0 from
(vTarget <= vTop && vTop <= vBot) to vTarget < vTop.

This prevents NODATA values when vTop > vBot due to roundoff errors.